### PR TITLE
updated Dockerfile to allow variables to be set for a TLS key and cert

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM alpine:latest
 LABEL maintiner="gdavid0510@gmail.com"
 
 ENV SERVER "localhost:5900"
+ENV CRT ""
+ENV KEY ""
 WORKDIR /
 
 COPY start.sh /start.sh

--- a/README.md
+++ b/README.md
@@ -19,3 +19,11 @@ Build from `master` branch.
 ### `SERVER`
 * IP address and port of VNC server host.
 * **DEFAULT** `localhost:5900`
+
+### `KEY`
+* Key file for TLS encryption
+* **DEFAULT** `empty`
+
+### `CRT`
+* Cert file for TLS encryption
+* **DEFAULT** `empty`

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,9 @@
 #!/bin/sh
 
-/novnc/utils/launch.sh --vnc $SERVER
+if [ $KEY ] && [ $CRT ]; then
+	/novnc/utils/novnc_proxy --ssl-only --vnc $SERVER --cert $CRT --key $KEY
+elif [ $CRT ]; then
+	/novnc/utils/novnc_proxy --ssl-only --vnc $SERVER --cert $CRT
+else
+	/novnc/utils/novnc_proxy --vnc $SERVER;
+fi


### PR DESCRIPTION
Updated bash file to use latest release of noVNC and check if the
Key and Crt variables are set and if so require https access.

TLS certificates can either be attached within volume or copied to the container after initial run